### PR TITLE
各プラットフォーム毎のデフォルトエンコーディングでスクリプトを開かず、UTF-8で読み込むように修正

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/script/ScriptViewContext.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/script/ScriptViewContext.java
@@ -29,7 +29,8 @@ public class ScriptViewContext {
     public HistoryManager historyManager;
     public FileModificationChecker fileModificationChecker;
     public ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
-
+    public String encoding = "UTF-8";
+    
     public void setIsModified(boolean isModified) {
         this.isModified = isModified;
         updateTitleBar();

--- a/src/main/java/com/change_vision/astah/extension/plugin/script/command/OpenCommand.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/script/command/OpenCommand.java
@@ -3,9 +3,10 @@ package com.change_vision.astah.extension.plugin.script.command;
 import java.awt.Cursor;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 import javax.script.ScriptEngine;
 import javax.swing.JOptionPane;
@@ -15,10 +16,12 @@ import com.change_vision.astah.extension.plugin.script.util.FileChooser;
 import com.change_vision.astah.extension.plugin.script.util.Messages;
 
 public class OpenCommand {
+    public static final String ENCODING = "UTF-8";
+    
     public static void execute(ScriptViewContext context) {
         execute(context, null);
     }
-
+    
     public static void execute(ScriptViewContext context, String filePath) {
         if (context.isModified) {
             int result = JOptionPane.showConfirmDialog(context.dialog,
@@ -42,7 +45,7 @@ public class OpenCommand {
         File f = new File(filePath);
         context.dialog.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(f));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(f), ENCODING));
             context.scriptTextArea.read(reader, null);
             reader.close();
             context.scriptTextArea.discardAllEdits();

--- a/src/main/java/com/change_vision/astah/extension/plugin/script/command/OpenCommand.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/script/command/OpenCommand.java
@@ -16,8 +16,6 @@ import com.change_vision.astah.extension.plugin.script.util.FileChooser;
 import com.change_vision.astah.extension.plugin.script.util.Messages;
 
 public class OpenCommand {
-    public static final String ENCODING = "UTF-8";
-    
     public static void execute(ScriptViewContext context) {
         execute(context, null);
     }
@@ -45,7 +43,7 @@ public class OpenCommand {
         File f = new File(filePath);
         context.dialog.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(f), ENCODING));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(f), context.encoding));
             context.scriptTextArea.read(reader, null);
             reader.close();
             context.scriptTextArea.discardAllEdits();

--- a/src/main/java/com/change_vision/astah/extension/plugin/script/command/SaveCommand.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/script/command/SaveCommand.java
@@ -2,8 +2,8 @@ package com.change_vision.astah.extension.plugin.script.command;
 
 import java.awt.Cursor;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 
 import com.change_vision.astah.extension.plugin.script.ScriptViewContext;
 import com.change_vision.astah.extension.plugin.script.util.FileChooser;
@@ -25,11 +25,11 @@ public class SaveCommand {
         context.dialog.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         try {
             context.fileModificationChecker.stop();
-            FileWriter fw = new FileWriter(context.currentFile);
+            PrintWriter writer = new PrintWriter(context.currentFile, context.encoding);
             String text = context.scriptTextArea.getText();
             int textSize = text.length();
-            fw.write(context.scriptTextArea.getText(), 0, textSize);
-            fw.close();
+            writer.write(context.scriptTextArea.getText(), 0, textSize);
+            writer.close();
             context.fileModificationChecker.start();
             context.setIsModified(false);
             context.statusBar.setText(Messages.getMessage("status.saved") + fileName);


### PR DESCRIPTION
@kamura デフォルトエンコーディングでファイルを読み込むため、日本語を利用したUTF-8でエンコーディングファイルを読み込めない。
スクリプトはOS個別のエンコードで読み込まず、一般的なUTF-8で読み込むとしては如何でしょうか。