### PR TITLE
fix #9 以前開いていたフォルダを、スクリプトファイルを開くでデフォルトで開いてほしい

### DIFF
--- a/src/main/java/com/change_vision/astah/extension/plugin/script/util/FileChooser.java
+++ b/src/main/java/com/change_vision/astah/extension/plugin/script/util/FileChooser.java
@@ -2,11 +2,14 @@ package com.change_vision.astah.extension.plugin.script.util;
 
 import java.awt.Dialog;
 import java.awt.FileDialog;
+import java.io.File;
 
 import javax.swing.JFileChooser;
 
 public class FileChooser {
     private static final String OS = System.getProperty("os.name").toLowerCase();
+    
+    private static File directory = null;
     
     public static String chooseFileToLoad(Dialog parentDialog) {
         return chooseFile(parentDialog, Messages.getMessage("open_script_dialog.title"), FileDialog.LOAD);
@@ -28,9 +31,11 @@ public class FileChooser {
     
     private static String chooseFileByFileDialog(Dialog parentDialog, String title, int mode) {
         FileDialog fileDialog = new FileDialog(parentDialog, title, mode);
+        if(directory != null) fileDialog.setDirectory(directory.getPath());
         fileDialog.setVisible(true);
         String selectedFile = fileDialog.getFile();
         if (selectedFile != null) {
+            directory = new File(fileDialog.getDirectory());
             return fileDialog.getDirectory() + selectedFile;
         } else {
             return null;
@@ -39,6 +44,7 @@ public class FileChooser {
     
     private static String chooseFileByJFileChooser(Dialog parentDialog, String title, int mode) {
         JFileChooser chooser = new JFileChooser();
+        if(directory != null) chooser.setCurrentDirectory(directory);
         chooser.setDialogTitle(title);
         int returnValue = 0;
         if (mode == FileDialog.LOAD) {
@@ -48,6 +54,7 @@ public class FileChooser {
         }
         
         if (returnValue == JFileChooser.APPROVE_OPTION) {
+            directory = chooser.getSelectedFile().getParentFile();
             return chooser.getSelectedFile().getAbsolutePath();
         } else {
             return null;


### PR DESCRIPTION
#9 

***

|   |   |  |
|---|---|---|
|1|スクリプトビューを開く|  |
|2|スクリプトファイルを開くダイアログからスクリプトファイルを開く|  |
|3|スクリプトファイルを開くダイアログ を開く|前回選択したスクリプトファイルが入っているフォルダが表示されていること|
